### PR TITLE
updates logstash to use new elasticsearch node

### DIFF
--- a/logstash/config/twitter.conf
+++ b/logstash/config/twitter.conf
@@ -10,7 +10,7 @@ input {
 }
 output {  
     elasticsearch {
-        hosts => elasticsearch
+        hosts =>  ["elasticsearch-node:9200"]
         index => "tweets-%{+YYYY.MM.dd}"
     }
 }


### PR DESCRIPTION
also changes the syntax of the logstash config. It was not correct after updating to 5.3